### PR TITLE
r/aws_cloudformation_stack_set: Add support for `operation_preferences.concurrency_mode`

### DIFF
--- a/internal/service/cloudformation/stack_set.go
+++ b/internal/service/cloudformation/stack_set.go
@@ -139,6 +139,11 @@ func resourceStackSet() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"concurrency_mode": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ValidateDiagFunc: enum.Validate[awstypes.ConcurrencyMode](),
+						},
 						"failure_tolerance_count": {
 							Type:          schema.TypeInt,
 							Optional:      true,

--- a/website/docs/r/cloudformation_stack_set.html.markdown
+++ b/website/docs/r/cloudformation_stack_set.html.markdown
@@ -112,6 +112,7 @@ This resource supports the following arguments:
 
 The `operation_preferences` configuration block supports the following arguments:
 
+* `concurrency_mode` - (Optional) Specifies how the concurrency level behaves during the operation execution. Valid values are `STRICT_FAILURE_TOLERANCE` and `SOFT_FAILURE_TOLERANCE`.
 * `failure_tolerance_count` - (Optional) The number of accounts, per Region, for which this operation can fail before AWS CloudFormation stops the operation in that Region.
 * `failure_tolerance_percentage` - (Optional) The percentage of accounts, per Region, for which this stack operation can fail before AWS CloudFormation stops the operation in that Region.
 * `max_concurrent_count` - (Optional) The maximum number of accounts in which to perform this operation at one time.

--- a/website/docs/r/cloudformation_stack_set_instance.html.markdown
+++ b/website/docs/r/cloudformation_stack_set_instance.html.markdown
@@ -107,11 +107,11 @@ The `deployment_targets` configuration block supports the following arguments:
 
 The `operation_preferences` configuration block supports the following arguments:
 
+* `concurrency_mode` - (Optional) Specifies how the concurrency level behaves during the operation execution. Valid values are `STRICT_FAILURE_TOLERANCE` and `SOFT_FAILURE_TOLERANCE`.
 * `failure_tolerance_count` - (Optional) Number of accounts, per Region, for which this operation can fail before AWS CloudFormation stops the operation in that Region.
 * `failure_tolerance_percentage` - (Optional) Percentage of accounts, per Region, for which this stack operation can fail before AWS CloudFormation stops the operation in that Region.
 * `max_concurrent_count` - (Optional) Maximum number of accounts in which to perform this operation at one time.
 * `max_concurrent_percentage` - (Optional) Maximum percentage of accounts in which to perform this operation at one time.
-* `concurrency_mode` - (Optional) Specifies how the concurrency level behaves during the operation execution. Valid values are `STRICT_FAILURE_TOLERANCE` and `SOFT_FAILURE_TOLERANCE`.
 * `region_concurrency_type` - (Optional) Concurrency type of deploying StackSets operations in Regions, could be in parallel or one Region at a time. Valid values are `SEQUENTIAL` and `PARALLEL`.
 * `region_order` - (Optional) Order of the Regions in where you want to perform the stack operation.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The `aws_cloudformation_stack_set` resource should support an `operation_preferences.concurrency_mode` argument, and it should pass this value to the [`UpdateStackSet` API operation](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStackSet.html).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #38498
Closes #38882

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ TF_ACC=1 go test ./internal/service/cloudformation/... -v -count 1 -parallel 1 -run='TestAccCloudFormationStackSet_'
=== RUN   TestAccCloudFormationStackSet_basic
=== PAUSE TestAccCloudFormationStackSet_basic
=== RUN   TestAccCloudFormationStackSet_disappears
=== PAUSE TestAccCloudFormationStackSet_disappears
=== RUN   TestAccCloudFormationStackSet_administrationRoleARN
=== PAUSE TestAccCloudFormationStackSet_administrationRoleARN
=== RUN   TestAccCloudFormationStackSet_description
=== PAUSE TestAccCloudFormationStackSet_description
=== RUN   TestAccCloudFormationStackSet_executionRoleName
=== PAUSE TestAccCloudFormationStackSet_executionRoleName
=== RUN   TestAccCloudFormationStackSet_managedExecution
=== PAUSE TestAccCloudFormationStackSet_managedExecution
=== RUN   TestAccCloudFormationStackSet_name
=== PAUSE TestAccCloudFormationStackSet_name
=== RUN   TestAccCloudFormationStackSet_operationPreferences
=== PAUSE TestAccCloudFormationStackSet_operationPreferences
=== RUN   TestAccCloudFormationStackSet_concurrencyMode
=== PAUSE TestAccCloudFormationStackSet_concurrencyMode
=== RUN   TestAccCloudFormationStackSet_parameters
=== PAUSE TestAccCloudFormationStackSet_parameters
=== RUN   TestAccCloudFormationStackSet_Parameters_default
    stack_set_test.go:528: this resource does not currently ignore unconfigured CloudFormation template parameters with the Default property
--- SKIP: TestAccCloudFormationStackSet_Parameters_default (0.00s)
=== RUN   TestAccCloudFormationStackSet_Parameters_noEcho
    stack_set_test.go:582: this resource does not currently ignore CloudFormation template parameters with the NoEcho property
--- SKIP: TestAccCloudFormationStackSet_Parameters_noEcho (0.00s)
=== RUN   TestAccCloudFormationStackSet_PermissionModel_serviceManaged
    stack_set_test.go:628: API does not support enabling Organizations access (in particular, creating the Stack Sets IAM Service-Linked Role)
--- SKIP: TestAccCloudFormationStackSet_PermissionModel_serviceManaged (0.00s)
=== RUN   TestAccCloudFormationStackSet_tags
=== PAUSE TestAccCloudFormationStackSet_tags
=== RUN   TestAccCloudFormationStackSet_templateBody
=== PAUSE TestAccCloudFormationStackSet_templateBody
=== RUN   TestAccCloudFormationStackSet_templateURL
=== PAUSE TestAccCloudFormationStackSet_templateURL
=== RUN   TestAccCloudFormationStackSet_autoDeploymentEnabled
=== PAUSE TestAccCloudFormationStackSet_autoDeploymentEnabled
=== RUN   TestAccCloudFormationStackSet_autoDeploymentDisabled
=== PAUSE TestAccCloudFormationStackSet_autoDeploymentDisabled
=== RUN   TestAccCloudFormationStackSet_delegatedAdministrator
=== PAUSE TestAccCloudFormationStackSet_delegatedAdministrator
=== CONT  TestAccCloudFormationStackSet_basic
--- PASS: TestAccCloudFormationStackSet_basic (34.75s)
=== CONT  TestAccCloudFormationStackSet_concurrencyMode
--- PASS: TestAccCloudFormationStackSet_concurrencyMode (61.56s)
=== CONT  TestAccCloudFormationStackSet_delegatedAdministrator
--- PASS: TestAccCloudFormationStackSet_delegatedAdministrator (53.60s)
=== CONT  TestAccCloudFormationStackSet_autoDeploymentDisabled
    stack_set_test.go:853: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSet_autoDeploymentDisabled (0.29s)
=== CONT  TestAccCloudFormationStackSet_autoDeploymentEnabled
    stack_set_test.go:814: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSet_autoDeploymentEnabled (0.29s)
=== CONT  TestAccCloudFormationStackSet_templateURL
--- PASS: TestAccCloudFormationStackSet_templateURL (47.86s)
=== CONT  TestAccCloudFormationStackSet_templateBody
--- PASS: TestAccCloudFormationStackSet_templateBody (45.65s)
=== CONT  TestAccCloudFormationStackSet_tags
=== CONT  TestAccCloudFormationStackSet_parameters
--- PASS: TestAccCloudFormationStackSet_tags (60.74s)
--- PASS: TestAccCloudFormationStackSet_parameters (75.14s)
=== CONT  TestAccCloudFormationStackSet_executionRoleName
=== CONT  TestAccCloudFormationStackSet_operationPreferences
--- PASS: TestAccCloudFormationStackSet_executionRoleName (45.58s)
--- PASS: TestAccCloudFormationStackSet_operationPreferences (105.12s)
=== CONT  TestAccCloudFormationStackSet_name
--- PASS: TestAccCloudFormationStackSet_name (58.80s)
=== CONT  TestAccCloudFormationStackSet_managedExecution
--- PASS: TestAccCloudFormationStackSet_managedExecution (30.59s)
=== CONT  TestAccCloudFormationStackSet_administrationRoleARN
--- PASS: TestAccCloudFormationStackSet_administrationRoleARN (45.62s)
=== CONT  TestAccCloudFormationStackSet_description
--- PASS: TestAccCloudFormationStackSet_description (45.38s)
=== CONT  TestAccCloudFormationStackSet_disappears
--- PASS: TestAccCloudFormationStackSet_disappears (28.53s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation     739.653s
```
