### PR TITLE
r/aws_cloudformation_stack_set_instance: Resource deletion respects `operation_preferences`

### DIFF
--- a/internal/service/cloudformation/stack_set_instance.go
+++ b/internal/service/cloudformation/stack_set_instance.go
@@ -472,6 +472,10 @@ func resourceStackSetInstanceDelete(ctx context.Context, d *schema.ResourceData,
 		input.DeploymentTargets = dt
 	}
 
+	if v, ok := d.GetOk("operation_preferences"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		input.OperationPreferences = expandOperationPreferences(v.([]interface{})[0].(map[string]interface{}))
+	}
+
 	log.Printf("[DEBUG] Deleting CloudFormation StackSet Instance: %s", d.Id())
 	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.OperationInProgressException](ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
 		return conn.DeleteStackInstances(ctx, input)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
During resource deletion (`resourceStackSetInstanceDelete()`), the configuration's `operation_preferences` should be passed to the [`DeleteStackInstances` API operation](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DeleteStackInstances.html), e.g. targets should be deleted according to any specified concurrency limits.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38881

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Using delegated-admin account:

```console
$ TF_ACC=1 go test ./internal/service/cloudformation/... -v -count 1 -parallel 1 -run='TestAccCloudFormationStackSetInstance_'
=== RUN   TestAccCloudFormationStackSetInstance_basic
=== PAUSE TestAccCloudFormationStackSetInstance_basic
=== RUN   TestAccCloudFormationStackSetInstance_disappears
=== PAUSE TestAccCloudFormationStackSetInstance_disappears
=== RUN   TestAccCloudFormationStackSetInstance_Disappears_stackSet
=== PAUSE TestAccCloudFormationStackSetInstance_Disappears_stackSet
=== RUN   TestAccCloudFormationStackSetInstance_parameterOverrides
=== PAUSE TestAccCloudFormationStackSetInstance_parameterOverrides
=== RUN   TestAccCloudFormationStackSetInstance_deploymentTargets
=== PAUSE TestAccCloudFormationStackSetInstance_deploymentTargets
=== RUN   TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU
=== PAUSE TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU
=== RUN   TestAccCloudFormationStackSetInstance_operationPreferences
=== PAUSE TestAccCloudFormationStackSetInstance_operationPreferences
=== RUN   TestAccCloudFormationStackSetInstance_concurrencyMode
=== PAUSE TestAccCloudFormationStackSetInstance_concurrencyMode
=== RUN   TestAccCloudFormationStackSetInstance_delegatedAdministrator
=== PAUSE TestAccCloudFormationStackSetInstance_delegatedAdministrator
=== CONT  TestAccCloudFormationStackSetInstance_basic
--- PASS: TestAccCloudFormationStackSetInstance_basic (84.35s)
=== CONT  TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU
    stack_set_instance_test.go:258: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU (1.46s)
=== CONT  TestAccCloudFormationStackSetInstance_delegatedAdministrator
    stack_set_instance_test.go:377: skipping tests; missing IAM service-linked role /aws-service-role/member.org.stacksets.cloudformation.amazonaws.com. Please create the role and retry
--- SKIP: TestAccCloudFormationStackSetInstance_delegatedAdministrator (0.94s)
=== CONT  TestAccCloudFormationStackSetInstance_concurrencyMode
    stack_set_instance_test.go:339: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSetInstance_concurrencyMode (2.48s)
=== CONT  TestAccCloudFormationStackSetInstance_operationPreferences
    stack_set_instance_test.go:304: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSetInstance_operationPreferences (2.15s)
=== CONT  TestAccCloudFormationStackSetInstance_parameterOverrides
--- PASS: TestAccCloudFormationStackSetInstance_parameterOverrides (151.17s)
=== CONT  TestAccCloudFormationStackSetInstance_deploymentTargets
    stack_set_instance_test.go:209: this AWS account must be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSetInstance_deploymentTargets (1.45s)
=== CONT  TestAccCloudFormationStackSetInstance_Disappears_stackSet
--- PASS: TestAccCloudFormationStackSetInstance_Disappears_stackSet (76.62s)
=== CONT  TestAccCloudFormationStackSetInstance_disappears
--- PASS: TestAccCloudFormationStackSetInstance_disappears (81.67s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation     402.463s
```

Using org management account:

```console
$ TF_ACC=1 go test ./internal/service/cloudformation/... -v -count 1 -parallel 1 -run='TestAccCloudFormationStackSetInstance_'
=== RUN   TestAccCloudFormationStackSetInstance_basic
=== PAUSE TestAccCloudFormationStackSetInstance_basic
=== RUN   TestAccCloudFormationStackSetInstance_disappears
=== PAUSE TestAccCloudFormationStackSetInstance_disappears
=== RUN   TestAccCloudFormationStackSetInstance_Disappears_stackSet
=== PAUSE TestAccCloudFormationStackSetInstance_Disappears_stackSet
=== RUN   TestAccCloudFormationStackSetInstance_parameterOverrides
=== PAUSE TestAccCloudFormationStackSetInstance_parameterOverrides
=== RUN   TestAccCloudFormationStackSetInstance_deploymentTargets
=== PAUSE TestAccCloudFormationStackSetInstance_deploymentTargets
=== RUN   TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU
=== PAUSE TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU
=== RUN   TestAccCloudFormationStackSetInstance_operationPreferences
=== PAUSE TestAccCloudFormationStackSetInstance_operationPreferences
=== RUN   TestAccCloudFormationStackSetInstance_concurrencyMode
=== PAUSE TestAccCloudFormationStackSetInstance_concurrencyMode
=== RUN   TestAccCloudFormationStackSetInstance_delegatedAdministrator
=== PAUSE TestAccCloudFormationStackSetInstance_delegatedAdministrator
=== CONT  TestAccCloudFormationStackSetInstance_basic
--- PASS: TestAccCloudFormationStackSetInstance_basic (83.53s)
=== CONT  TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU
--- PASS: TestAccCloudFormationStackSetInstance_DeploymentTargets_emptyOU (73.29s)
=== CONT  TestAccCloudFormationStackSetInstance_delegatedAdministrator
    stack_set_instance_test.go:376: this AWS account must not be the management account of an AWS Organization
--- SKIP: TestAccCloudFormationStackSetInstance_delegatedAdministrator (1.35s)
=== CONT  TestAccCloudFormationStackSetInstance_concurrencyMode
--- PASS: TestAccCloudFormationStackSetInstance_concurrencyMode (92.27s)
=== CONT  TestAccCloudFormationStackSetInstance_operationPreferences
--- PASS: TestAccCloudFormationStackSetInstance_operationPreferences (99.72s)
=== CONT  TestAccCloudFormationStackSetInstance_parameterOverrides
--- PASS: TestAccCloudFormationStackSetInstance_parameterOverrides (148.12s)
=== CONT  TestAccCloudFormationStackSetInstance_deploymentTargets
--- PASS: TestAccCloudFormationStackSetInstance_deploymentTargets (89.09s)
=== CONT  TestAccCloudFormationStackSetInstance_Disappears_stackSet
=== CONT  TestAccCloudFormationStackSetInstance_disappears
--- PASS: TestAccCloudFormationStackSetInstance_Disappears_stackSet (77.51s)
--- PASS: TestAccCloudFormationStackSetInstance_disappears (82.89s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudformation     747.916s
``` 