### PR TITLE
r/aws_macie2_organization_configuration: Automatically enable and add new organization accounts as Macie member accounts

### DIFF
--- a/internal/service/macie2/macie2_test.go
+++ b/internal/service/macie2/macie2_test.go
@@ -55,6 +55,9 @@ func TestAccMacie2_serial(t *testing.T) {
 			acctest.CtBasic:      testAccOrganizationAdminAccount_basic,
 			acctest.CtDisappears: testAccOrganizationAdminAccount_disappears,
 		},
+		"OrganizationConfiguration": {
+			acctest.CtBasic: testAccOrganizationConfiguration_basic,
+		},
 		"Member": {
 			acctest.CtBasic:                         testAccMember_basic,
 			acctest.CtDisappears:                    testAccMember_disappears,

--- a/internal/service/macie2/organization_configuration.go
+++ b/internal/service/macie2/organization_configuration.go
@@ -1,0 +1,76 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package macie2
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/macie2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+)
+
+// @SDKResource("aws_macie2_organization_configuration", name="Organization Configuration")
+func resourceOrganizationConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateWithoutTimeout: resourceOrganizationConfigurationUpdate,
+		UpdateWithoutTimeout: resourceOrganizationConfigurationUpdate,
+		DeleteWithoutTimeout: schema.NoopContext,
+		ReadWithoutTimeout:   resourceOrganizationConfigurationRead,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"auto_enable": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceOrganizationConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).Macie2Client(ctx)
+
+	input := macie2.UpdateOrganizationConfigurationInput{
+		AutoEnable: aws.Bool(d.Get("auto_enable").(bool)),
+	}
+
+	log.Printf("[DEBUG] Updating Macie organization configuration: %+v", input)
+
+	_, err := conn.UpdateOrganizationConfiguration(ctx, &input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "updating Macie organization configuration failed: %s", err)
+	}
+
+	d.SetId("macie2-org-config")
+
+	return append(diags, resourceOrganizationConfigurationRead(ctx, d, meta)...)
+}
+
+func resourceOrganizationConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	conn := meta.(*conns.AWSClient).Macie2Client(ctx)
+
+	input := macie2.DescribeOrganizationConfigurationInput{}
+	output, err := conn.DescribeOrganizationConfiguration(ctx, &input)
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading Macie organization configuration failed: %s", err)
+	}
+
+	d.Set("auto_enable", output.AutoEnable)
+
+	return diags
+}

--- a/internal/service/macie2/organization_configuration_test.go
+++ b/internal/service/macie2/organization_configuration_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package macie2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func testAccOrganizationConfiguration_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_macie2_organization_configuration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Macie2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrganizationConfigurationConfig_autoEnable(true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "auto_enable", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccOrganizationConfigurationConfig_autoEnable(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "auto_enable", acctest.CtFalse),
+				),
+			},
+		},
+	})
+}
+
+func testAccOrganizationConfigurationConfig_autoEnable(autoEnable bool) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+resource "aws_macie2_organization_admin_account" "test" {
+  admin_account_id = data.aws_caller_identity.current.account_id
+}
+
+resource "aws_macie2_organization_configuration" "test" {
+  auto_enable = %[1]t
+
+  depends_on = [
+	aws_macie2_organization_admin_account.test
+  ]
+}
+`, autoEnable)
+}

--- a/internal/service/macie2/service_package_gen.go
+++ b/internal/service/macie2/service_package_gen.go
@@ -72,6 +72,11 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			TypeName: "aws_macie2_organization_admin_account",
 			Name:     "Organization Admin Account",
 		},
+		{
+			Factory:  resourceOrganizationConfiguration,
+			TypeName: "aws_macie2_organization_configuration",
+			Name:     "Organization Configuration",
+		},
 	}
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #26762
or 
Closes #0000
--->

Closes #26762


<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc PKG=macie2 TESTS=TestAccMacie2_serial/OrganizationConfiguration
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.0 test ./internal/service/macie2/... -v -count 1 -parallel 20 -run='TestAccMacie2_serial/OrganizationConfiguration'  -timeout 360m
=== RUN   TestAccMacie2_serial
=== PAUSE TestAccMacie2_serial
=== CONT  TestAccMacie2_serial
=== RUN   TestAccMacie2_serial/OrganizationConfiguration
=== RUN   TestAccMacie2_serial/OrganizationConfiguration/basic
2024/09/04 17:39:43 [DEBUG] GET https://releases.hashicorp.com/terraform/1.9.5/index.json
2024/09/04 17:39:43 [DEBUG] GET https://releases.hashicorp.com/terraform/1.9.5/terraform_1.9.5_SHA256SUMS.72D7468F.sig
2024/09/04 17:39:43 [DEBUG] GET https://releases.hashicorp.com/terraform/1.9.5/terraform_1.9.5_SHA256SUMS
2024/09/04 17:39:43 [DEBUG] GET https://releases.hashicorp.com/terraform/1.9.5/terraform_1.9.5_linux_amd64.zip
--- PASS: TestAccMacie2_serial (48.41s)
    --- PASS: TestAccMacie2_serial/OrganizationConfiguration (48.41s)
        --- PASS: TestAccMacie2_serial/OrganizationConfiguration/basic (48.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/macie2     48.565s
```
